### PR TITLE
Check docker compose version

### DIFF
--- a/ecosystem.js
+++ b/ecosystem.js
@@ -144,7 +144,7 @@ try {
 	execSync('docker compose version').toString();
 	dockerComposeCommand = 'docker compose'
 } catch (error) {
-	console.log(error.status, error.message)
+	// Fall back to default value
 }
 
 if (action === "down") {


### PR DESCRIPTION
Using `docker-compose`  in `init` case resulted in:
```
$ node ecosystem.js init       
                     
Run a one-off command on a service.
For example:

    $ docker-compose run web python manage.py shell

By default, linked services will be started, unless they are already
running. If you do not want to start linked services, use
`docker-compose run --no-deps SERVICE COMMAND [ARGS...]`.
Run a one-off command on a service.

For example:

    $ docker-compose run web python manage.py shell

By default, linked services will be started, unless they are already
running. If you do not want to start linked services, use
`docker-compose run --no-deps SERVICE COMMAND [ARGS...]`.
...
```