### PR TITLE
Make wallet-db healthcheck succeed much sooner

### DIFF
--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -105,8 +105,10 @@ services:
       MYSQL_UNIX_PORT: 3307
     healthcheck:
       test: ["CMD", "mariadb" ,"-uroot", "-proot", "--protocol=TCP", "-hlocalhost", "--port=3307",  "-estatus"]
-      timeout: 20s
-      retries: 10
+      start_period: 60s
+      #start_interval: 5s  # Not yet supported it seems, but upcoming: https://github.com/docker/compose/issues/10830
+      interval: 5s         # Delete this line when start_interval becomes supported
+      timeout: 2s
     volumes:
       # persist data files into `datadir` volume managed by docker
       - datadir:/var/lib/mysql


### PR DESCRIPTION
The default `interval` is 30 seconds, meaning the dependent services will always take at least 30 seconds to start up. This reduces the `interval` to 5 seconds, letting the dependent services usually start up in 5 or 10 seconds.