### PR TITLE
Align service definitions with backend PR #25 and frontend PR #47

### DIFF
--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -129,6 +129,8 @@ services:
     build:
       context: $PWD/wallet-backend-server
       dockerfile: development.Dockerfile
+      secrets:
+        - wallet-backend-server-npmrc
     image: wallet-backend-server
     restart: always
     ports:
@@ -170,3 +172,7 @@ volumes:
   datadir:
   cache:
     driver: local
+
+secrets:
+  wallet-backend-server-npmrc:
+    file: $PWD/wallet-backend-server/.npmrc

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -157,9 +157,8 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - $PWD/wallet-frontend:/home/node/app
-      - /home/node/app/node_modules
-      - ./.vscode/:/home/node/app/.vscode
+      - ./wallet-frontend:/app:ro
+      - ./.vscode/:/app/.vscode:ro
 
 volumes:
   datadir:

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -137,10 +137,12 @@ services:
       wallet-db:
         condition: service_healthy
     volumes:
-      - ./wallet-backend-server:/home/node/app
-      - /home/node/app/dist
-      - /home/node/app/node_modules
-      - ./.vscode/:/home/node/app/.vscode
+      - ./wallet-backend-server:/app:ro
+      - ./.vscode/:/app/.vscode:ro
+      - type: tmpfs
+        target: /dist
+        tmpfs:
+          mode: 01777
     deploy:
       resources:
           limits:

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -159,6 +159,7 @@ services:
     volumes:
       - ./wallet-frontend/public:/app/public:ro
       - ./wallet-frontend/src:/app/src:ro
+      - ./wallet-frontend/.env:/app/.env:ro
       - ./.vscode/:/app/.vscode:ro
       - type: tmpfs
         target: /app/node_modules/.cache

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -157,8 +157,13 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./wallet-frontend:/app:ro
+      - ./wallet-frontend/public:/app/public:ro
+      - ./wallet-frontend/src:/app/src:ro
       - ./.vscode/:/app/.vscode:ro
+      - type: tmpfs
+        target: /app/node_modules/.cache
+        tmpfs:
+          mode: 01777
 
 volumes:
   datadir:

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -146,9 +146,8 @@ if (action === "down") {
 }
 
 if (action === "init") {
-	execSync(`${dockerComposeCommand} run --rm -t --workdir /home/node/app/cli wallet-backend-server sh -c '
+	execSync(`${dockerComposeCommand} run --rm -t --workdir /app/cli --env NODE_PATH=/cli_node_modules wallet-backend-server sh -c '
 		set -e # Exit on error
-		yarn install
 		export DB_HOST="wallet-db"
 		export DB_PORT="3307"
 		export DB_USER="root"

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -210,8 +210,8 @@ if (action !== "up") {
 
 if (daemonMode === false) {
 	console.log("Performing 'docker compose up'");
-	execSync(`${dockerComposeCommand} up`, { stdio: 'inherit' });
+	execSync(`${dockerComposeCommand} up --build`, { stdio: 'inherit' });
 } else {
 	console.log("Performing 'docker compose up -d'");
-	execSync(`${dockerComposeCommand} up -d`, { stdio: 'inherit' });
+	execSync(`${dockerComposeCommand} up --build -d`, { stdio: 'inherit' });
 }


### PR DESCRIPTION
Companion PR of gunet/wallet-backend-server#25 and gunet/wallet-frontend#47.

The current setup causes some issues when dependencies change. The `node_modules` volumes go out of sync with the application image, because the volume inherits its initial state from the image at the time the volume is created but is then never updated unless you run `yarn install` inside the container or delete and recreate the volume.

This change makes the containers use a readonly `node_modules` embedded in the image, mounts the host-mounted directories as readonly and moves the `tsc` output of wallet-backend-server into a tmpfs volume. The optimized Dockerfile layer order enables us to use `--build` in `node ecosystem.js up` to always rebuild the images on each startup, which will rarely be needed unless dependencies change.

