### PR TITLE
Optimize dev Dockerfiles for rebuild speed and readonly filesystem, and don't embed .npmrc

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -35,3 +35,5 @@ jobs:
         file: ./Dockerfile
         push: ${{ inputs.docker-push }}
         tags: ${{ inputs.image-tag }}
+        secret-files: |
+          npmrc=./.npmrc

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 build
 docker-compose.yml
 .github-token
+.npmrc

--- a/.npmrc.template
+++ b/.npmrc.template
@@ -1,0 +1,2 @@
+//npm.pkg.github.com/:_authToken=${GITHUB_AUTH_TOKEN}
+@gunet:registry=https://npm.pkg.github.com/

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -129,6 +129,8 @@ services:
     build:
       context: $PWD/wallet-backend-server
       dockerfile: development.Dockerfile
+      secrets:
+        - wallet-backend-server-npmrc
     image: wallet-backend-server
     restart: always
     ports:
@@ -170,3 +172,7 @@ volumes:
   datadir:
   cache:
     driver: local
+
+secrets:
+  wallet-backend-server-npmrc:
+    file: $PWD/wallet-backend-server/.npmrc

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -9,6 +9,8 @@ services:
     build:
       context: $PWD/wallet-enterprise
       dockerfile: development.Dockerfile
+      secrets:
+        - npmrc
     image: wallet-enterprise
     restart: always
     ports:
@@ -37,6 +39,8 @@ services:
     build:
       context: $PWD/wallet-enterprise
       dockerfile: development.Dockerfile
+      secrets:
+        - npmrc
     image: wallet-enterprise
     restart: always
     ports:
@@ -65,6 +69,8 @@ services:
     build:
       context: $PWD/wallet-enterprise
       dockerfile: development.Dockerfile
+      secrets:
+        - npmrc
     image: wallet-enterprise
     restart: always
     ports:
@@ -130,7 +136,7 @@ services:
       context: $PWD/wallet-backend-server
       dockerfile: development.Dockerfile
       secrets:
-        - wallet-backend-server-npmrc
+        - npmrc
     image: wallet-backend-server
     restart: always
     ports:
@@ -153,6 +159,8 @@ services:
     build:
       context: $PWD/wallet-frontend
       dockerfile: development.Dockerfile
+      secrets:
+        - npmrc
     image: wallet-frontend
     container_name: wallet-frontend
     hostname: wallet-frontend
@@ -174,5 +182,5 @@ volumes:
     driver: local
 
 secrets:
-  wallet-backend-server-npmrc:
-    file: $PWD/wallet-backend-server/.npmrc
+  npmrc:
+    file: ./.npmrc

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -19,15 +19,17 @@ services:
       wallet-db:
         condition: service_healthy
     volumes:
-      - ./wallet-enterprise:/home/node/app
-      - ./wallet-enterprise-configurations/vid-issuer/config/config.development.ts:/home/node/app/config/config.development.ts
-      - ./wallet-enterprise-configurations/vid-issuer/keys:/home/node/app/keys
-      - ./wallet-enterprise-configurations/vid-issuer/src/configuration:/home/node/app/src/configuration
-      - ./wallet-enterprise-configurations/vid-issuer/public/styles/styles.css:/home/node/app/public/styles/styles.css
-      - ./wallet-enterprise-configurations/vid-issuer/public/images:/home/node/app/public/images
-      - /home/node/app/dist
-      - /home/node/app/node_modules
-      - ./.vscode/:/home/node/app/.vscode
+      - ./wallet-enterprise:/app:ro
+      - ./wallet-enterprise-configurations/vid-issuer/config/config.development.ts:/app/config/config.development.ts:ro
+      - ./wallet-enterprise-configurations/vid-issuer/keys:/app/keys:ro
+      - ./wallet-enterprise-configurations/vid-issuer/src/configuration:/app/src/configuration:ro
+      - ./wallet-enterprise-configurations/vid-issuer/public/styles/styles.css:/app/public/styles/styles.css:ro
+      - ./wallet-enterprise-configurations/vid-issuer/public/images:/app/public/images:ro
+      - ./.vscode/:/app/.vscode:ro
+      - type: tmpfs
+        target: /app/dist  # Not /dist here because of relative imports that assume dist/ and keys/, views/ etc. are sibling dirs
+        tmpfs:
+          mode: 01777
     deploy:
       resources:
           limits:
@@ -49,15 +51,17 @@ services:
       wallet-db:
         condition: service_healthy
     volumes:
-      - ./wallet-enterprise:/home/node/app
-      - ./wallet-enterprise-configurations/diploma-issuer/config/config.development.ts:/home/node/app/config/config.development.ts
-      - ./wallet-enterprise-configurations/diploma-issuer/keys:/home/node/app/keys
-      - ./wallet-enterprise-configurations/diploma-issuer/src/configuration:/home/node/app/src/configuration
-      - ./wallet-enterprise-configurations/diploma-issuer/public/styles/styles.css:/home/node/app/public/styles/styles.css
-      - ./wallet-enterprise-configurations/diploma-issuer/public/images:/home/node/app/public/images
-      - /home/node/app/dist
-      - /home/node/app/node_modules
-      - ./.vscode/:/home/node/app/.vscode
+      - ./wallet-enterprise:/app:ro
+      - ./wallet-enterprise-configurations/diploma-issuer/config/config.development.ts:/app/config/config.development.ts:ro
+      - ./wallet-enterprise-configurations/diploma-issuer/keys:/app/keys:ro
+      - ./wallet-enterprise-configurations/diploma-issuer/src/configuration:/app/src/configuration:ro
+      - ./wallet-enterprise-configurations/diploma-issuer/public/styles/styles.css:/app/public/styles/styles.css:ro
+      - ./wallet-enterprise-configurations/diploma-issuer/public/images:/app/public/images:ro
+      - ./.vscode/:/app/.vscode:ro
+      - type: tmpfs
+        target: /app/dist
+        tmpfs:
+          mode: 01777
     deploy:
       resources:
           limits:
@@ -79,15 +83,17 @@ services:
       wallet-db:
         condition: service_healthy
     volumes:
-      - ./wallet-enterprise:/home/node/app
-      - ./wallet-enterprise-configurations/acme-verifier/config/config.development.ts:/home/node/app/config/config.development.ts
-      - ./wallet-enterprise-configurations/acme-verifier/keys:/home/node/app/keys
-      - ./wallet-enterprise-configurations/acme-verifier/src/configuration:/home/node/app/src/configuration
-      - ./wallet-enterprise-configurations/acme-verifier/public/styles/styles.css:/home/node/app/public/styles/styles.css
-      - ./wallet-enterprise-configurations/acme-verifier/public/images:/home/node/app/public/images
-      - /home/node/app/dist
-      - /home/node/app/node_modules
-      - ./.vscode/:/home/node/app/.vscode
+      - ./wallet-enterprise:/app:ro
+      - ./wallet-enterprise-configurations/acme-verifier/config/config.development.ts:/app/config/config.development.ts:ro
+      - ./wallet-enterprise-configurations/acme-verifier/keys:/app/keys:ro
+      - ./wallet-enterprise-configurations/acme-verifier/src/configuration:/app/src/configuration:ro
+      - ./wallet-enterprise-configurations/acme-verifier/public/styles/styles.css:/app/public/styles/styles.css:ro
+      - ./wallet-enterprise-configurations/acme-verifier/public/images:/app/public/images:ro
+      - ./.vscode/:/app/.vscode:ro
+      - type: tmpfs
+        target: /app/dist
+        tmpfs:
+          mode: 01777
     deploy:
       resources:
           limits:

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -157,9 +157,8 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - $PWD/wallet-frontend:/home/node/app
-      - /home/node/app/node_modules
-      - ./.vscode/:/home/node/app/.vscode
+      - ./wallet-frontend:/app:ro
+      - ./.vscode/:/app/.vscode:ro
 
 volumes:
   datadir:

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -137,10 +137,12 @@ services:
       wallet-db:
         condition: service_healthy
     volumes:
-      - ./wallet-backend-server:/home/node/app
-      - /home/node/app/dist
-      - /home/node/app/node_modules
-      - ./.vscode/:/home/node/app/.vscode
+      - ./wallet-backend-server:/app:ro
+      - ./.vscode/:/app/.vscode:ro
+      - type: tmpfs
+        target: /dist
+        tmpfs:
+          mode: 01777
     deploy:
       resources:
           limits:

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -159,6 +159,7 @@ services:
     volumes:
       - ./wallet-frontend/public:/app/public:ro
       - ./wallet-frontend/src:/app/src:ro
+      - ./wallet-frontend/.env:/app/.env:ro
       - ./.vscode/:/app/.vscode:ro
       - type: tmpfs
         target: /app/node_modules/.cache

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -157,8 +157,13 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./wallet-frontend:/app:ro
+      - ./wallet-frontend/public:/app/public:ro
+      - ./wallet-frontend/src:/app/src:ro
       - ./.vscode/:/app/.vscode:ro
+      - type: tmpfs
+        target: /app/node_modules/.cache
+        tmpfs:
+          mode: 01777
 
 volumes:
   datadir:

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -146,9 +146,8 @@ if (action === "down") {
 }
 
 if (action === "init") {
-	execSync(`${dockerComposeCommand} run --rm -t --workdir /home/node/app/cli wallet-backend-server sh -c '
+	execSync(`${dockerComposeCommand} run --rm -t --workdir /app/cli --env NODE_PATH=/cli_node_modules wallet-backend-server sh -c '
 		set -e # Exit on error
-		yarn install
 		export DB_HOST="wallet-db"
 		export DB_PORT="3307"
 		export DB_USER="root"

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -210,8 +210,8 @@ if (action !== "up") {
 
 if (daemonMode === false) {
 	console.log("Performing 'docker compose up'");
-	execSync(`${dockerComposeCommand} up`, { stdio: 'inherit' });
+	execSync(`${dockerComposeCommand} up --build`, { stdio: 'inherit' });
 } else {
 	console.log("Performing 'docker compose up -d'");
-	execSync(`${dockerComposeCommand} up -d`, { stdio: 'inherit' });
+	execSync(`${dockerComposeCommand} up --build -d`, { stdio: 'inherit' });
 }


### PR DESCRIPTION
Companion PR of wwWallet/wallet-backend-server#34, wwWallet/wallet-enterprise#9 and wwWallet/wallet-frontend#108.

The current setup causes some issues when dependencies change. The `node_modules` volumes go out of sync with the application image, because the volume inherits its initial state from the image at the time the volume is created but is then never updated unless you run `yarn install` inside the container or delete and recreate the volume.

This change makes the containers use a readonly `node_modules` embedded in the image, mounts the host-mounted directories as readonly and moves the `tsc` output into a tmpfs volume. The optimized Dockerfile layer order enables us to use `--build` in `node ecosystem.js up` to always rebuild the images on each startup, which will rarely be needed unless dependencies change.

Finally, this mounts `.npmrc` as a [secret mount](https://docs.docker.com/engine/reference/builder/#run---mounttypesecret) only at build time, instead of embedding the GitHub token into the resulting image.