### PR TITLE
Add init command to ensure db table creation

### DIFF
--- a/ecosystem.js
+++ b/ecosystem.js
@@ -145,6 +145,12 @@ if (action === "down") {
 	process.exit();
 }
 
+if (action === "init") {
+	console.log("Performing init");
+	init()
+	process.exit();
+}
+
 function init() {
 	return execSync(`${dockerComposeCommand} run --rm -t --workdir /app/cli --env NODE_PATH=/cli_node_modules wallet-backend-server sh -c '
 		set -e # Exit on error
@@ -171,8 +177,8 @@ function init() {
 	'`, { stdio: 'inherit' });
 }
 
-if (action !== "up") {
-	console.log("Error: First argument must be 'up' or 'down'");
+if (action != 'up') {
+	console.log("Error: First argument must be 'up' or 'down' or 'init'");
 	help();
 	process.exit();
 }
@@ -210,10 +216,7 @@ if (action !== "up") {
 	}
 }
 
-
 if (daemonMode === false) {
-	console.log("Initializing database");
-	init();
 	console.log("Performing 'docker compose up'");
 	execSync(`${dockerComposeCommand} up --build`, { stdio: 'inherit' });
 } else {

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -218,10 +218,8 @@ if (action !== 'up') {
 
 if (daemonMode === false) {
 	console.log("Performing 'docker compose up'");
-	init()
 	execSync(`${dockerComposeCommand} up --build`, { stdio: 'inherit' });
 } else {
 	console.log("Performing 'docker compose up -d'");
-	init()
 	execSync(`${dockerComposeCommand} up --build -d`, { stdio: 'inherit' });
 }

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -177,7 +177,7 @@ function init() {
 	'`, { stdio: 'inherit' });
 }
 
-if (action != 'up') {
+if (action !== 'up') {
 	console.log("Error: First argument must be 'up' or 'down' or 'init'");
 	help();
 	process.exit();

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -218,8 +218,10 @@ if (action !== 'up') {
 
 if (daemonMode === false) {
 	console.log("Performing 'docker compose up'");
+	init()
 	execSync(`${dockerComposeCommand} up --build`, { stdio: 'inherit' });
 } else {
 	console.log("Performing 'docker compose up -d'");
+	init()
 	execSync(`${dockerComposeCommand} up --build -d`, { stdio: 'inherit' });
 }

--- a/ecosystem.js
+++ b/ecosystem.js
@@ -218,8 +218,10 @@ if (action != 'up') {
 
 if (daemonMode === false) {
 	console.log("Performing 'docker compose up'");
+	init()
 	execSync(`${dockerComposeCommand} up --build`, { stdio: 'inherit' });
 } else {
 	console.log("Performing 'docker compose up -d'");
+	init()
 	execSync(`${dockerComposeCommand} up --build -d`, { stdio: 'inherit' });
 }


### PR DESCRIPTION
The `init();` in `ecosystem.js` failed during the first launch of the ecosystem because `wallet-backend-server` was not properly initiliazed yet. This restores a previously used ecosystem command so that we can initialize the issuers manually after the first launch.
