### PR TITLE
Make notification capability configurable

### DIFF
--- a/ecosystem.js
+++ b/ecosystem.js
@@ -212,6 +212,13 @@ if (action !== 'up') {
 		configContent = configContent.replace(/WEBAUTHN_RP_ID/g, "localhost");
 		configContent = configContent.replace(/WEBAUTHN_ORIGIN/g, walletClientOrigin);
 	
+		// Replacing the whole string so that the value of enabled is of type boolean and not string
+		if (args.includes('--no-notifications')) {
+			configContent = configContent.replace(/enabled: "NOTIFICATIONS_ENABLED"/g, 'enabled: false');
+		} else {
+			configContent = configContent.replace(/enabled: "NOTIFICATIONS_ENABLED"/g, 'enabled: true');
+		}
+
 		fs.writeFileSync(configPath, configContent);
 	}
 }


### PR DESCRIPTION
Paired with https://github.com/wwWallet/wallet-backend-server/pull/40

Add ecosystem argument so that we can disable notifications:
`node ecosystem.js -c --no-notifications`