### PR TITLE
Use the batch size configuration for vid issuer

### DIFF
--- a/wallet-enterprise-configurations/vid-issuer/config/index.ts
+++ b/wallet-enterprise-configurations/vid-issuer/config/index.ts
@@ -20,7 +20,7 @@ export const config = {
 		skipConsent: false,
 		defaultCredentialConfigurationIds: [ "urn:credential:vid" ],
 		batchCredentialIssuance: {
-			batchSize: 5,
+			batchSize: 1,
 		}
 	},
 	presentationFlow: {

--- a/wallet-enterprise-configurations/vid-issuer/config/index.ts
+++ b/wallet-enterprise-configurations/vid-issuer/config/index.ts
@@ -19,6 +19,9 @@ export const config = {
 	issuanceFlow: {
 		skipConsent: false,
 		defaultCredentialConfigurationIds: [ "urn:credential:vid" ],
+		batchCredentialIssuance: {
+			batchSize: 5,
+		}
 	},
 	presentationFlow: {
 		response_mode: "direct_post.jwt"


### PR DESCRIPTION
At the moment the vid-issuer is configured to issue one credential per batch. You can configure it by changing the number `issuanceFlow.issuanceFlow.batchSize`  on the `config/index.ts` file. This configuration is optional and issuer will issue only one credential by-default

See example:
 (https://github.com/wwWallet/wallet-ecosystem/pull/107/commits/2d33d5f02766890c4d2aff101281d7a7b248f63a#diff-5a09de92499b2395fc2c6bb196150557a673d81371ff8b4d11577f84337e91e7)