### PR TITLE
siteConfig.name value as page title for issuer and verifier setups

### DIFF
--- a/wallet-enterprise-configurations/acme-verifier/src/configuration/titles.ts
+++ b/wallet-enterprise-configurations/acme-verifier/src/configuration/titles.ts
@@ -1,7 +1,8 @@
 // titles.ts
+import { config } from "../../config";
 
 const titles = {
-  index: "wwWallet Verifier",
+  index: config?.siteConfig?.name || "wwWallet Verifier",
   // Add other titles for different routes or pages here if needed
 };
 

--- a/wallet-enterprise-configurations/issuer/src/configuration/titles.ts
+++ b/wallet-enterprise-configurations/issuer/src/configuration/titles.ts
@@ -1,7 +1,8 @@
 // titles.ts
+import { config } from "../../config";
 
 const titles = {
-  index: "wwWallet Issuer",
+  index: config?.siteConfig?.name || "wwWallet Issuer",
   // Add other titles for different routes or pages here if needed
 };
 


### PR DESCRIPTION
If siteConfig.name exists, its easier and less error prone to generate the title from there instead of manually changing it for every deployment.