### PR TITLE
Build node_modules reliably in wallet-frontend development image

### DIFF
--- a/docker/wallet-frontend.development.Dockerfile
+++ b/docker/wallet-frontend.development.Dockerfile
@@ -17,8 +17,7 @@ RUN yarn add https://github.com/wwwallet/mdl.git#deploy
 
 FROM node:22-bullseye-slim AS development
 
-ENV NODE_PATH=/node_modules
-COPY --from=dependencies /dependencies/node_modules /node_modules
+COPY --from=dependencies /dependencies/node_modules /app/node_modules
 
 WORKDIR /app
 ENV NODE_ENV=development

--- a/docker/wallet-frontend.development.Dockerfile
+++ b/docker/wallet-frontend.development.Dockerfile
@@ -27,7 +27,7 @@ CMD [ "yarn", "start-docker" ]
 COPY ./wallet-frontend/ .
 
 # :hammer_and_wrench: Fix: Ensure Vite has permissions to write inside `/app`
-RUN mkdir -p /app/node_modules/.vite && chmod -R 777 /app/node_modules
+RUN mkdir -p /app/node_modules/.vite && chown -R node /app/node_modules
 
-# Set user last so everything is readonly by default
+# Set user last so everything else is readonly by default
 USER node

--- a/docker/wallet-frontend.development.Dockerfile.dockerignore
+++ b/docker/wallet-frontend.development.Dockerfile.dockerignore
@@ -1,0 +1,16 @@
+# Keep these in sync with wallet-frontend/.dockerignore
+/wallet-frontend/node_modules/
+/wallet-frontend/build/
+/wallet-frontend/dist/
+/wallet-frontend/.git
+/wallet-frontend/.gitattributes
+/wallet-frontend/.gitignore
+/wallet-frontend/.npmrc
+/wallet-frontend/.npmrc.template
+/wallet-frontend/.vscode
+/wallet-frontend/README.md
+
+
+# These will be mounted from host
+/wallet-frontend/src/
+/wallet-frontend/public/


### PR DESCRIPTION
I had a bunch of issues getting dc_sw-jwt to work, because `./node_modules/wallet-common/` wasn't reliably rebuilt correctly in the frontend dev image, because there were two conflicting `node_modules` directories in the image:

```
ENV NODE_PATH=/node_modules
COPY --from=dependencies /dependencies/node_modules /node_modules

WORKDIR /app
ENV NODE_ENV=development
CMD [ "yarn", "start-docker" ]

# src/ and public/ will be mounted from host, but we need some config files in the image for startup
COPY ./wallet-frontend/ .
```

The first two lines set up the `node_modules` directory to be at `/node_modules` and copy that directory from the `dependencies` stage, but the last line also copies in `./wallet-frontend/node_modules/` into `/app/node_modules`, and it seems like Vite prefers that directory over the one declared in `NODE_PATH`.

This is all fixed by simply getting rid of `/node_modules` and copying the `node_modules` from the `dependencies` stage into `/app/node_modules` instead. A new `dockerignore` file ensures that `./wallet-frontend/node_modules/` is ignored while copying in `./wallet-frontend/`, so that the existing `node_modules` isn't accidentally overwritten.