### PR TITLE
Add dockerfile-target input to docker-build-push workflow and make dockerfile-path optional

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -13,7 +13,8 @@ on:
 
       dockerfile-path:
         type: string
-        required: true
+        required: false
+        default: ''
 
       dockerfile-target:
         type: string


### PR DESCRIPTION
This will enable us to do things like [this](https://github.com/wwWallet/wallet-frontend/commit/9544e97c74b68c75efae44e4b711bd2760c3164a) to use the same `Dockerfile` for both development, test and deployment builds.