### PR TITLE
Mount tmpfs on node_modules/{.vite,vite-temp} in wallet-frontend

### DIFF
--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -132,7 +132,11 @@ services:
       - ./wallet-frontend/.env:/app/.env:rw
       - ./.vscode/:/app/.vscode:rw
       - type: tmpfs
-        target: /app/node_modules/.cache
+        target: /app/node_modules/.vite
+        tmpfs:
+          mode: 01777
+      - type: tmpfs
+        target: /app/node_modules/.vite-temp
         tmpfs:
           mode: 01777
 

--- a/docker/wallet-frontend.development.Dockerfile
+++ b/docker/wallet-frontend.development.Dockerfile
@@ -25,8 +25,5 @@ CMD [ "yarn", "start-docker" ]
 # src/ and public/ will be mounted from host, but we need some config files in the image for startup
 COPY ./wallet-frontend/ .
 
-# :hammer_and_wrench: Fix: Ensure Vite has permissions to write inside `/app`
-RUN mkdir -p /app/node_modules/.vite && chown -R node /app/node_modules
-
-# Set user last so everything else is readonly by default
+# Set user last so everything is readonly by default
 USER node


### PR DESCRIPTION
It's definitely not clear from the error message:

```
wallet-frontend | failed to load config from /app/vite.config.ts
wallet-frontend | error when starting dev server:
wallet-frontend | Error: EACCES: permission denied, open '/app/vite.config.ts.timestamp-1751539478105-f34f6275d342f.mjs'
wallet-frontend |     at async open (node:internal/fs/promises:639:25)
wallet-frontend |     at async Object.writeFile (node:internal/fs/promises:1213:14)
wallet-frontend |     at async loadConfigFromBundledFile (file:///app/node_modules/vite/dist/node/chunks/dep-Cg8OuIew.js:55387:5)
wallet-frontend |     at async bundleAndLoadConfigFile (file:///app/node_modules/vite/dist/node/chunks/dep-Cg8OuIew.js:55232:22)
wallet-frontend |     at async loadConfigFromFile (file:///app/node_modules/vite/dist/node/chunks/dep-Cg8OuIew.js:55194:44)
wallet-frontend |     at async resolveConfig (file:///app/node_modules/vite/dist/node/chunks/dep-Cg8OuIew.js:54702:24)
wallet-frontend |     at async _createServer (file:///app/node_modules/vite/dist/node/chunks/dep-Cg8OuIew.js:44689:18)
wallet-frontend |     at async CAC.<anonymous> (file:///app/node_modules/vite/dist/node/cli.js:750:20)
```

but it turns out this was addressed in Vite 6.0.0, and the file it's actually trying to write is in `./node_modules/.vite-temp/`: https://github.com/vitejs/vite/pull/18509/files#diff-11e17761d4ecfee8f8fde15c6d79b7bc0260176396a30dfd8e6f6bbaf5af4745R1696

Presumably `./vite.config.ts.timestamp-XXX.mjs` is a fallback attempt after the `.vite-temp/` attempt fails. Either way, adding a tmpfs mount for `.vite-temp/` removes the need for the permissions workaround in the Dockerfile, enabling the Docker container to use fully-readonly filesystems (except those overridden by volume mounts).