### PR TITLE
Make src and .env volume mounts readonly in wallet-frontend

### DIFF
--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -128,8 +128,8 @@ services:
       - 3000:3000
     volumes:
       - ./wallet-frontend/public:/app/public:rw
-      - ./wallet-frontend/src:/app/src:rw
-      - ./wallet-frontend/.env:/app/.env:rw
+      - ./wallet-frontend/src:/app/src:ro
+      - ./wallet-frontend/.env:/app/.env:ro
       - ./.vscode/:/app/.vscode:rw
       - type: tmpfs
         target: /app/node_modules/.cache


### PR DESCRIPTION
Vite should never write to these files, so mounting them as readonly helps prevent polluting the host filesystem with files owned by root and the like.