### PR TITLE
Use relative paths for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,13 +1,13 @@
 [submodule "wallet-backend-server"]
 	path = wallet-backend-server
-	url = git@github.com:wwwallet/wallet-backend-server.git
+	url = ../../wwwallet/wallet-backend-server.git
 [submodule "wallet-frontend"]
 	path = wallet-frontend
-	url = git@github.com:wwwallet/wallet-frontend.git
+	url = ../../wwwallet/wallet-frontend.git
 [submodule "wallet-enterprise"]
 	path = wallet-enterprise
-	url = git@github.com:wwwallet/wallet-enterprise.git
+	url = ../../wwwallet/wallet-enterprise.git
 [submodule "lib/wallet-common"]
 	path = lib/wallet-common
-	url = git@github.com:wwWallet/wallet-common.git
+	url = ../../wwWallet/wallet-common.git
 	branch = master


### PR DESCRIPTION
This change will enable users to easily clone the repo without having an SSH key configured.
Currently, submodules are using SSH for cloning:
https://github.com/wwWallet/wallet-ecosystem/blob/284e137d9e3a2fd35c74d565c1d5caf5ca99252d/.gitmodules#L1-L6 If we use relative paths, then whatever method/protocol the user used to clone wallet-ecosystem will be used instead.

Users who have already cloned the repo will have to run `git submodule sync` ([docs](https://git-scm.com/docs/git-submodule#Documentation/git-submodule.txt-sync--recursive--path)) to apply the changes to their `.git/config`.