### PR TITLE
Pass kid as uint8array to avoid mdl bug

### DIFF
--- a/wallet-enterprise-configurations/issuer/src/configuration/issuerSigner.ts
+++ b/wallet-enterprise-configurations/issuer/src/configuration/issuerSigner.ts
@@ -45,15 +45,15 @@ export const issuerSigner: CredentialSigner = {
 		expirationDate.setFullYear(expirationDate.getFullYear() + 1);
 		const signedDocument = await document
 			.addValidityInfo({
-				signed: signed,
+				signed: new Date(),
 				validUntil: expirationDate,
 				validFrom: validFromDate,
 			})
-			.addDeviceKeyInfo({ deviceKey: holderPublicKeyJwk })
+			.addDeviceKeyInfo({ deviceKey: {...holderPublicKeyJwk, kid: cborEncode(holderPublicKeyJwk.kid) } as any })
 			.sign({
 				issuerPrivateKey: {
 					...issuerPrivateKeyJwk,
-					kid: issuerJwkKid, // only used to avoid undefined value on kid of the IssuerAuth
+					kid: cborEncode(issuerJwkKid) as any, // only used to avoid undefined value on kid of the IssuerAuth
 				},
 				issuerCertificate: issuerCertPem,
 				alg: 'ES256',


### PR DESCRIPTION
Hotfix to bypass https://github.com/auth0-lab/mdl/issues/55

By passing kid as a uint8array, mdl uses it as-is. If a string kid is passed, the library does not encode it properly, resulting in parsing and verification errors on verifiers.