### PR TITLE
Prevent wallet-backend-server template injector from replacing property name references

### DIFF
--- a/ecosystem.js
+++ b/ecosystem.js
@@ -226,18 +226,18 @@ function buildImages() {
 		const dbName = 'wallet';
 
 		let configContent = fs.readFileSync(configPath, 'utf-8');
-		configContent = configContent.replace(/SERVICE_URL/g, serviceUrl);
-		configContent = configContent.replace(/SERVICE_SECRET/g, secret);
-		configContent = configContent.replace(/SERVICE_PORT/g, servicePort);
-		configContent = configContent.replace(/DB_HOST/g, dbHost);
-		configContent = configContent.replace(/DB_PORT/g, dbPort);
-		configContent = configContent.replace(/DB_USER/g, dbUser);
-		configContent = configContent.replace(/DB_PASSWORD/g, dbPassword);
-		configContent = configContent.replace(/DB_NAME/g, dbName);
-		configContent = configContent.replace(/WALLET_CLIENT_URL/g, walletClientUrl);
+		configContent = configContent.replace(/\$\{SERVICE_URL\}/g, serviceUrl);
+		configContent = configContent.replace(/\$\{SERVICE_SECRET\}/g, secret);
+		configContent = configContent.replace(/\$\{SERVICE_PORT\}/g, servicePort);
+		configContent = configContent.replace(/\$\{DB_HOST\}/g, dbHost);
+		configContent = configContent.replace(/\$\{DB_PORT\}/g, dbPort);
+		configContent = configContent.replace(/\$\{DB_USER\}/g, dbUser);
+		configContent = configContent.replace(/\$\{DB_PASSWORD\}/g, dbPassword);
+		configContent = configContent.replace(/\$\{DB_NAME\}/g, dbName);
+		configContent = configContent.replace(/\$\{WALLET_CLIENT_URL\}/g, walletClientUrl);
 
-		configContent = configContent.replace(/WEBAUTHN_RP_ID/g, "localhost");
-		configContent = configContent.replace(/WEBAUTHN_ORIGIN/g, walletClientOrigin);
+		configContent = configContent.replace(/\$\{WEBAUTHN_RP_ID\}/g, "localhost");
+		configContent = configContent.replace(/\$\{WEBAUTHN_ORIGIN\}/g, walletClientOrigin);
 
 		fs.writeFileSync(configPath, configContent);
 	}


### PR DESCRIPTION
This is mutually dependent on https://github.com/wwWallet/wallet-backend-server/pull/111.

After commit 626e02d23ef2026429cea03ecab74569b0ccd499 in wallet-backend-server, this template injection also replaces for example `process.env.PORT` with `process.env.3307`, causing syntax errors and preventing the server from starting up.